### PR TITLE
Set BUZZER_PIN to output only before actually buzzing

### DIFF
--- a/H8mini_test/src/main.c
+++ b/H8mini_test/src/main.c
@@ -303,14 +303,19 @@ vbatt = battadc;
 			if (rxmode == RX_MODE_BIND)
 				buzzer_delay = 20000000;
 
-			if (!buzzer_init && maintime > buzzer_delay) 
+			if (maintime > buzzer_delay)
 			{
-				if (gpio_init_buzzer())
-					buzzer_init = 1;
-			}
-			else if (buzzer_init && maintime > buzzer_delay)
-			{
-				buzzer();
+				if (lowbatt || failsafe || buzzer_init)
+				{
+					if (!buzzer_init)
+					{
+						buzzer_init = gpio_init_buzzer();
+					}
+					else
+					{
+						buzzer();
+					}
+				}
 			}
 #endif
 


### PR DESCRIPTION
Same change as this one
    https://github.com/silver13/H101-acro/commit/ef477df18922d2528dd61a03ec172073d6cda61f
in the H101 fw.
