### PR TITLE
Fixed linker error

### DIFF
--- a/H8mini_test/src/drv_esc.c
+++ b/H8mini_test/src/drv_esc.c
@@ -251,5 +251,8 @@ if ( onground ) pwm = ((float)PWMTOP/PWMTOP_US) * ESC_THROTTLEOFF;
 	
 }
 
+void motorbeep()
+{
+}
 
 #endif


### PR DESCRIPTION
Without this the linker gives the following error:
    .\output\Project.axf: Error: L6218E: Undefined symbol motorbeep (referred from control.o).
when using the drv_esc.c driver.