### PR TITLE
Make sure pwm_set(3, ...) is called last.

### DIFF
--- a/H8mini_test/src/main.c
+++ b/H8mini_test/src/main.c
@@ -113,10 +113,10 @@ int main(void)
 #ifdef SERVO_DRIVER
     servo_init();
 #endif    
-	pwm_set(MOTOR_FL, 0);	// FL
-	pwm_set(MOTOR_FR, 0);
-	pwm_set(MOTOR_BL, 0);	// BL
-	pwm_set(MOTOR_BR, 0);	// FR
+	for (int i = 0; i <= 3; i++)
+	  {
+		  pwm_set(i, 0);
+	  }
 
 	time_init();
 


### PR DESCRIPTION
pwm_set(3, ...) is special in the Dshot driver, as it triggers the bit-banging.