### PR TITLE
configurable adc pins

### DIFF
--- a/H8mini_test/src/drv_adc.c
+++ b/H8mini_test/src/drv_adc.c
@@ -1,11 +1,71 @@
 #include "gd32f1x0.h"
 #include "drv_adc.h"
 #include "util.h"
+#include "hardware.h"
+#include "stdio.h"
 
-uint16_t adcarray[4];
+uint16_t adcarray[10];
+
+struct ADC_SETTINGS
+{
+	uint8_t id;
+	uint8_t pin;
+	GPIO_TypeDef* port;
+	uint8_t channel;
+	float adc_readout;
+	float adc_value;
+
+};
+
+struct ADC_SETTINGS adc_settings[] = 
+{
+#ifdef ADC_PA0
+	{ADC_PA0, GPIO_PIN_0, GPIOA,ADC_CHANNEL_0, ADC_PA0_READOUT, ADC_PA0_VALUE},
+#endif
+#ifdef ADC_PA1
+	{ADC_PA1, GPIO_PIN_1, GPIOA,ADC_CHANNEL_1, ADC_PA1_READOUT, ADC_PA1_VALUE},
+#endif
+#ifdef ADC_PA2
+	{ADC_PA2, GPIO_PIN_2, GPIOA,ADC_CHANNEL_2, ADC_PA2_READOUT, ADC_PA2_VALUE},
+#endif
+#ifdef ADC_PA3
+	{ADC_PA3, GPIO_PIN_3, GPIOA,ADC_CHANNEL_3, ADC_PA3_READOUT, ADC_PA3_VALUE},
+#endif
+#ifdef ADC_PA4
+	{ADC_PA4, GPIO_PIN_4, GPIOA,ADC_CHANNEL_4, ADC_PA4_READOUT, ADC_PA4_VALUE},
+#endif
+#ifdef ADC_PA5
+	{ADC_PA5, GPIO_PIN_5, GPIOA,ADC_CHANNEL_5, ADC_PA5_READOUT, ADC_PA5_VALUE},
+#endif
+#ifdef ADC_PA6
+	{ADC_PA6, GPIO_PIN_6, GPIOA,ADC_CHANNEL_6, ADC_PA6_READOUT, ADC_PA6_VALUE},
+#endif
+#ifdef ADC_PA7
+	{ADC_PA7, GPIO_PIN_7, GPIOA,ADC_CHANNEL_7, ADC_PA7_READOUT, ADC_PA7_VALUE},
+#endif
+#ifdef ADC_PB0
+	{ADC_PB0, GPIO_PIN_0, GPIOB,ADC_CHANNEL_8, ADC_PB0_READOUT, ADC_PB0_VALUE},
+#endif
+#ifdef ADC_PB1
+	{ADC_PB1, GPIO_PIN_1, GPIOB,ADC_CHANNEL_9, ADC_PB1_READOUT, ADC_PB1_VALUE},
+#endif
+};
 
 void adc_init(void)
 {
+
+	int size = sizeof(adc_settings) / sizeof(adc_settings[0]);
+
+	for (int i = 0; i < size; ++i)
+	{
+		GPIO_InitPara    GPIO_InitStructure;
+
+		GPIO_InitStructure.GPIO_Pin = adc_settings[i].pin ;
+		GPIO_InitStructure.GPIO_Mode = GPIO_MODE_AN;
+		GPIO_InitStructure.GPIO_PuPd = GPIO_PUPD_NOPULL ;
+		GPIO_Init(adc_settings[i].port, &GPIO_InitStructure);
+	}
+
 	DMA_InitPara DMA_InitStructure;
 	ADC_InitPara ADC_InitStructure;
 
@@ -18,7 +78,7 @@ void adc_init(void)
 	DMA_InitStructure.DMA_PeripheralBaseAddr = 0x4001244C;
 	DMA_InitStructure.DMA_MemoryBaseAddr = (uint32_t) adcarray;
 	DMA_InitStructure.DMA_DIR = DMA_DIR_PERIPHERALSRC;
-	DMA_InitStructure.DMA_BufferSize = 4;
+	DMA_InitStructure.DMA_BufferSize = size;
 	DMA_InitStructure.DMA_PeripheralInc = DMA_PERIPHERALINC_DISABLE;
 	DMA_InitStructure.DMA_MemoryInc = DMA_MEMORYINC_ENABLE;
 	DMA_InitStructure.DMA_PeripheralDataSize = DMA_PERIPHERALDATASIZE_HALFWORD;
@@ -37,16 +97,13 @@ void adc_init(void)
 	ADC_InitStructure.ADC_Mode_Continuous = ENABLE;
 	ADC_InitStructure.ADC_Trig_External = ADC_EXTERNAL_TRIGGER_MODE_NONE;
 	ADC_InitStructure.ADC_Data_Align = ADC_DATAALIGN_RIGHT;
-	ADC_InitStructure.ADC_Channel_Number = 4;
-
+	ADC_InitStructure.ADC_Channel_Number = size; 
 	ADC_Init(&ADC_InitStructure);
-	// current?
-	ADC_RegularChannel_Config(ADC_CHANNEL_7, 1, ADC_SAMPLETIME_239POINT5);
-	// battery channel
-	ADC_RegularChannel_Config(ADC_CHANNEL_5, 2, ADC_SAMPLETIME_239POINT5);
 
-	ADC_RegularChannel_Config(ADC_CHANNEL_4, 3, ADC_SAMPLETIME_239POINT5);
-	ADC_RegularChannel_Config(ADC_CHANNEL_1, 4, ADC_SAMPLETIME_239POINT5);
+	for (int i = 0; i < size; ++i)
+	{
+		ADC_RegularChannel_Config(adc_settings[i].channel, i+1, ADC_SAMPLETIME_239POINT5);
+	}
 
 	ADC_DMA_Enable(ENABLE);
 
@@ -57,31 +114,14 @@ void adc_init(void)
 	ADC_SoftwareStartConv_Enable(ENABLE);
 }
 
-float adc_read(int channel)
+float adc_read(int id)
 {
-	switch (channel)
-	  {
-	  case 0:
-		  return adcarray[0];
-		  //break;
-
-	  case 1:
-		  return mapf((float)adcarray[1], 2727.0, 3050.0, 3.77, 4.22);
-		  //break;
-
-	  case 2:
-		  return adcarray[2];
-		  //break;
-
-	  case 3:
-		  return adcarray[3];
-		  //break;        
-
-	  default:
-
-		  return 0;
-		  //break;
-	  }
-
-
+	for (int i = 0; i < sizeof(adc_settings) / sizeof(adc_settings[0]); ++i)
+	{
+		if (id == adc_settings[i].id)
+		{
+			return (float) adcarray[i] * ((float)(adc_settings[i].adc_value)/(float) (adc_settings[i].adc_readout)) ;
+		}
+	}
+	return 0.f;
 }

--- a/H8mini_test/src/drv_adc.h
+++ b/H8mini_test/src/drv_adc.h
@@ -1,4 +1,4 @@
 
 void adc_init(void);
-float adc_read(int channel);
+float adc_read(int id);
 

--- a/H8mini_test/src/hardware.h
+++ b/H8mini_test/src/hardware.h
@@ -19,6 +19,21 @@
 #define BUZZER_PIN_PORT  GPIOA
 #define BUZZER_DELAY     5e6 // 5 seconds after loss of tx or low bat before buzzer starts
 
+// Analog battery input pin and adc channel
+
+// divider setting for adc uses 2 measurements(readout/value).
+// the adc readout can be found in debug mode , debug.adcfilt
+// #enable DEBUG should be in config.h
+// default for 1/2 divider
+
+// uncomment to enable acd on a pin
+// POSSIBLE ADC PINS: PA0-PA7, PB0, PB1
+// the associated number is the id passed in to adc_read()
+
+#define ADC_ID_VOLTAGE 5
+#define ADC_PA5         ADC_ID_VOLTAGE
+#define ADC_PA5_READOUT 2727
+#define ADC_PA5_VALUE   3.77f
 
 
 //*** DO NOT ENABLE ESC DRIVER WITH BRUSHED MOTORS CONNECTED ***

--- a/H8mini_test/src/main.c
+++ b/H8mini_test/src/main.c
@@ -155,7 +155,7 @@ int main(void)
 
 	while (count < 64)
 	  {
-		  vbattfilt += adc_read(1);
+		  vbattfilt += adc_read(ADC_ID_VOLTAGE);
 		  count++;
 	  }
        // for randomising MAC adddress of ble app - this will make the int = raw float value        


### PR DESCRIPTION
Made adc pins configurable. 

I was not sure about the line:

ADC_InitStructure.ADC_Channel_Number = size; 

And the other three adc pins that were configured.

Also I did not test with H8mini since I do not have one.